### PR TITLE
Flexible versioning on TM

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
-  version = "v0.24.0"
+  version = "^v0.24.0"
 
 [[override]]
   name = "golang.org/x/net"


### PR DESCRIPTION
Locking to the specific build makes it difficult to import aiakos, it should be safe for this library to allow newer versions